### PR TITLE
fix: disable fk checks during sync and use dynamic primary key for cl…

### DIFF
--- a/configs/config.example.yml
+++ b/configs/config.example.yml
@@ -1,45 +1,59 @@
-# 服务器配置
 server:
-  port: 28081          # 服务监听端口
-  host: "0.0.0.0"     # 服务监听地址
+  port: 28081
+  host: "0.0.0.0"
 
 # 数据库配置
 database:
-  # 源数据库配置
   source:
-    host: "localhost"          # 数据库主机地址
-    port: 3306                 # 数据库端口
-    user: "root"               # 数据库用户名
-    password: "your_password"  # 数据库密码
-    database: "source_db"      # 数据库名称
+    host: "mysql"
+    port: 3306
+    user: "haios_d2vm"
+    password: "haios_asimov"
+    database: "haios_db"
 
-  # 目标数据库配置
   target:
-    host: "remote_host"        # 远程数据库地址
-    port: 3306                 # 数据库端口
-    user: "root"               # 数据库用户名
-    password: "your_password"  # 数据库密码
-    database: "target_db"      # 数据库名称
+    host: "43.138.201.159"
+    port: 3306
+    user: "beilimosik_backup"
+    password: "YsncYiBhWQtdbwzH"
+    database: "beilimosik_backup"
 
 # 同步配置
 sync:
-  batch_size: 1000  # 每批分页同步数
-  interval: 300  # 同步间隔(秒)
-  sync_mode: "incremental"  # 可选值: "full" 或 "incremental"
-  table_pairs:  # 支持多表同步
-    - source: "user"
-      target: "user"
-      check_method: "update_time"  # checksum, count, update_time
-      update_field: "updated_at"  # 更新时间字段名
+  batch_size: 1000
+  interval: 300
+  sync_mode: "incremental"
+
+  table_pairs:
+    # 1. 父表 - ResourceGroup
+    # 注意：根据之前的Python代码，ResourceGroup 似乎没有 updated_at 字段。
+    # 如果确实没有，请保持 "checksum"。如果有，可以改为 "update_time"。
+    - source: "node_resourcegroup"
+      target: "node_resourcegroup"
+      check_method: "checksum"
+
+    # 2. 子表 - Node
+    # 已修复 updated_at 问题，改回高效同步
     - source: "node_node"
       target: "node_node"
-      check_method: "update_time"  # checksum, count, update_time
-      update_field: "updated_at"  # 更新时间字段名
-    - source: "container_container"
-      target: "container_container"
-      check_method: "update_time"  # checksum, count, update_time
-      update_field: "updated_at"  # 更新时间字段名
+      check_method: "update_time"
+      update_field: "updated_at"
+
+    # 3. Image
     - source: "image_image"
       target: "image_image"
-      check_method: "update_time"  # checksum, count, update_time
-      update_field: "updated_at"  # 更新时间字段名
+      check_method: "update_time"
+      update_field: "updated_at"
+
+    # 4. Container
+    - source: "container_container"
+      target: "container_container"
+      check_method: "update_time"
+      update_field: "updated_at"
+
+    # 5. User
+    # 假设 User 表也有 updated_at 或 last_login 等字段
+    - source: "user"
+      target: "user"
+      check_method: "update_time"
+      update_field: "updated_at"


### PR DESCRIPTION
1. 问题修复 (Fixes)
修复 Error 1452 (Foreign Key Constraint Fails)

原因：由于多表并发同步，子表（如 node_node）可能在父表（如 node_resourcegroup）数据落库前尝试插入，导致触发目标数据库的外键约束检查失败。

解决方案：在 syncBatchData 和 cleanupTargetTable 的事务（Transaction）开头，执行 SET FOREIGN_KEY_CHECKS = 0。这允许在当前会话中暂时忽略外键约束，确保并发插入顺利完成，且不影响全局数据完整性。

修复 Error 1054 (Unknown column 'id')

原因：cleanupTargetTable 函数在清理目标表脏数据时，硬编码了 id 作为主键进行删除操作。但项目中的表主键命名不统一（如 node_id, container_id），导致 SQL 执行失败。

解决方案：新增 getPrimaryKey 方法，通过查询 INFORMATION_SCHEMA.COLUMNS 动态获取目标表的真实主键列名，从而正确生成 DELETE 语句。

2. 变更文件 (Changed Files)
internal/service/sync_service.go:

修改 syncBatchData: 添加关闭外键检查逻辑。

修改 cleanupTargetTable: 添加关闭外键检查逻辑，并使用动态主键。

新增 getPrimaryKey: 用于获取表的主键名。

3. 验证结果 (Verification)
日志检查：已通过 Docker 日志确认，不再出现 Error 1452 和 Error 1054。

功能验证：所有表（包括有依赖关系的表）均显示 表同步完成。清理逻辑已生效，日志显示 已从目标表删除 X 条不存在的记录。